### PR TITLE
formatting edits for yaml output

### DIFF
--- a/macros/PbPb_yaml.C
+++ b/macros/PbPb_yaml.C
@@ -138,11 +138,11 @@ void PbPb_yaml(int jetpt_bin = 7, int eta_bin = 4, bool dpt = false, int table =
 
       ostringstream tmpss;
       tmpss.clear();
-      tmpss << " - {name: RE, value: jet fragmentation function}" << endl;
-      tmpss << " - {name: pT(jet), value: " << jetpt_range[0][jetpt_bin] << " - " << jetpt_range[1][jetpt_bin] << "}" << endl;
-      tmpss << " - {name: abs. rapidity(jet), value: " << eta_range[0][eta_bin] << " - " << eta_range[1][eta_bin] << "}" << endl;
-      tmpss << " - {name: SQRT(S), units: GeV, value: '5020.0'}" << endl;
-      tmpss << " - {name: Centrality, value: pp}" << endl;
+      tmpss << "  - {name: RE, value: jet fragmentation function}" << endl;
+      tmpss << "  - {name: pT(jet), value: " << jetpt_range[0][jetpt_bin] << " - " << jetpt_range[1][jetpt_bin] << "}" << endl;
+      tmpss << "  - {name: abs. rapidity(jet), value: " << eta_range[0][eta_bin] << " - " << eta_range[1][eta_bin] << "}" << endl;
+      tmpss << "  - {name: SQRT(S), units: GeV, value: '5020.0'}" << endl;
+      tmpss << "  - {name: Centrality, value: pp}" << endl;
       dep_var_qual.push_back(tmpss.str());
 
       ry->add_dep_var_qualifiers(dep_var_qual);
@@ -175,12 +175,12 @@ void PbPb_yaml(int jetpt_bin = 7, int eta_bin = 4, bool dpt = false, int table =
 
       ostringstream tmpss;
       tmpss.clear();
-      if(!doratio)tmpss << " - {name: RE, value: jet fragmentation function}" << endl;
-      else tmpss << " - {name: RE, value: ratio of jet fragmentation function compared to pp collisions}" << endl;
-      tmpss << " - {name: pT(jet), value: " << jetpt_range[0][jetpt_bin] << " - " << jetpt_range[1][jetpt_bin] << "}" << endl;
-      tmpss << " - {name: abs. rapidity(jet), value: " << eta_range[0][eta_bin] << " - " << eta_range[1][eta_bin] << "}" << endl;
-      tmpss << " - {name: SQRT(S), units: GeV, value: '5020.0'}" << endl;
-      tmpss << " - {name: Centrality, value: " << centrality[i] << "}" << endl;
+      if(!doratio)tmpss << "  - {name: RE, value: jet fragmentation function}" << endl;
+      else tmpss << "  - {name: RE, value: ratio of jet fragmentation function compared to pp collisions}" << endl;
+      tmpss << "  - {name: pT(jet), value: " << jetpt_range[0][jetpt_bin] << " - " << jetpt_range[1][jetpt_bin] << "}" << endl;
+      tmpss << "  - {name: abs. rapidity(jet), value: " << eta_range[0][eta_bin] << " - " << eta_range[1][eta_bin] << "}" << endl;
+      tmpss << "  - {name: SQRT(S), units: GeV, value: '5020.0'}" << endl;
+      tmpss << "  - {name: Centrality, value: " << centrality[i] << "}" << endl;
       dep_var_qual.push_back(tmpss.str());
 
       ry->add_dep_var_qualifiers(dep_var_qual);

--- a/root_yaml.cc
+++ b/root_yaml.cc
@@ -141,6 +141,12 @@ void root_yaml::print_ind_variable(){
 }
 void root_yaml::print_dep_variable(){
 
+	if (first_dep_var)
+	{
+		ofs << "dependent_variables:" << endl;
+		first_dep_var = false;
+	}
+
    ofs << "- header: {name: " << dep_var_name << "}" << endl;
    print_dep_var_qualifiers();
       

--- a/root_yaml.cc
+++ b/root_yaml.cc
@@ -123,7 +123,7 @@ void root_yaml::set_dep_variable(vector<TH1 *> hstat_v, vector<TH1 *> hsys_p_v, 
 //prints...
 
 void root_yaml::print_dep_var_qualifiers(){
-   ofs << " qualifiers:" << endl;
+   ofs << "  qualifiers:" << endl;
    for (vector<string>::iterator it = dep_var_qualifiers.begin() ; it != dep_var_qualifiers.end(); ++it)
     ofs << *it ;
 }
@@ -150,11 +150,11 @@ void root_yaml::print_dep_variable(){
    ofs << "- header: {name: " << dep_var_name << "}" << endl;
    print_dep_var_qualifiers();
       
-   ofs << "values: " << endl;
+   ofs << "  values: " << endl;
    
    for(int i = 0; i < dep_var.size(); i++){
 	 
-      ofs << " - errors:" << endl;
+      ofs << "  - errors:" << endl;
       ofs << "    - {label: stat, symerror: " << dep_var_stat[i] << "}" << endl;
       ofs << "    - asymerror: {minus: " << dep_var_syslow[i] << ", plus: " << dep_var_syshigh[i] << "}" << endl;
       ofs << "      label: sys" << endl;

--- a/root_yaml.h
+++ b/root_yaml.h
@@ -24,7 +24,7 @@ class root_yaml {
       std::string ind_var_units;
       std::string outfile;
       std::ofstream ofs;
-	  bool first_dep_var = true;
+      bool first_dep_var = true;
    public:
       root_yaml();
       ~root_yaml();

--- a/root_yaml.h
+++ b/root_yaml.h
@@ -24,6 +24,7 @@ class root_yaml {
       std::string ind_var_units;
       std::string outfile;
       std::ofstream ofs;
+	  bool first_dep_var = true;
    public:
       root_yaml();
       ~root_yaml();


### PR DESCRIPTION
The format for HEPdata seems to not work with a single space as an indentation - that is not fixed. 
I have also added a line that says "dependent_variables", that should go above the "-header..." line for dependent variables.